### PR TITLE
fix: batch images is a list

### DIFF
--- a/scripts/sd-discord-webhook.py
+++ b/scripts/sd-discord-webhook.py
@@ -149,7 +149,7 @@ def check_safety(x_image):
 
 def censor_batch(x):
     x = copy.deepcopy(x)
-    x_samples_ddim_numpy = torch.stack([e.permute(1, 2, 0).numpy() for e in x])
+    x_samples_ddim_numpy = torch.stack([e.permute(1, 2, 0) for e in x]).numpy()
     has_nsfw_concept = check_safety(x_samples_ddim_numpy)
     return has_nsfw_concept
 

--- a/scripts/sd-discord-webhook.py
+++ b/scripts/sd-discord-webhook.py
@@ -149,7 +149,7 @@ def check_safety(x_image):
 
 def censor_batch(x):
     x = copy.deepcopy(x)
-    x_samples_ddim_numpy = x.permute(0, 2, 3, 1).numpy()
+    x_samples_ddim_numpy = torch.stack([e.permute(1, 2, 0).numpy() for e in x])
     has_nsfw_concept = check_safety(x_samples_ddim_numpy)
     return has_nsfw_concept
 


### PR DESCRIPTION
In [sd-webui-comfyui](https://github.com/ModelSurge/sd-webui-comfyui) we need `images` to be a list, so that each image in the list can have an arbitrary size, and so that the list size can change arbitrarily.

See https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11933 for details.